### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.vos
 *.vok
 .lia.cache
+.coq-native
 temp


### PR DESCRIPTION
On my machine the Coq compiler creates a ".coq-native" directory. I don't know what's up with it, but I guess is should be in gitignore.